### PR TITLE
feat: allow passing a custom logger

### DIFF
--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -44,21 +44,21 @@ describe("AppEnv", () => {
   });
 
   it("can be constructed with missing env vars if skip is set", () => {
-    const log = jest.spyOn(global.console, "log").mockImplementation(() => undefined);
+    const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
     const invalidEnvVars: Partial<typeof validEnvVars> = { ...validEnvVars };
     delete invalidEnvVars.NAME;
-    const conf = newConfig(AppConfig, invalidEnvVars, { ignoreErrors: true });
+    const conf = newConfig(AppConfig, invalidEnvVars, { ignoreErrors: true, logger });
     expect(conf.name).toBeUndefined();
-    expect(log).toHaveBeenCalledWith("Ignoring errors while instantiating config: NAME is not set");
+    expect(logger.info).toHaveBeenCalledWith("Ignoring errors while instantiating config: NAME is not set");
   });
 
   it("can be constructed with missing env vars and also not complain about it", () => {
-    const log = jest.spyOn(global.console, "log").mockImplementation(() => undefined);
+    const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
     const invalidEnvVars: Partial<typeof validEnvVars> = { ...validEnvVars };
     delete invalidEnvVars.NAME;
-    const conf = newConfig(AppConfig, invalidEnvVars, { ignoreErrors: true, doNotLogErrors: true });
+    const conf = newConfig(AppConfig, invalidEnvVars, { ignoreErrors: true, doNotLogErrors: true, logger });
     expect(conf.name).toBeUndefined();
-    expect(log).toHaveBeenCalledTimes(0);
+    expect(logger.error).toHaveBeenCalledTimes(0);
   });
 
   it("error message contains the name of all missing env vars", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,14 +67,14 @@ function logOrFailIfErrors(options: ConfigOptions, errors: Error[], ignoreErrors
   const { logger = console } = options;
   const message = errors.map((e) => e.message).join(", ");
   if (!ignoreErrors) {
-    log(logger.error, message, options);
+    maybeLog(logger.error, message, options);
     throw new ConfigError(message);
   } else {
-    log(logger.info, `Ignoring errors while instantiating config: ${message}`, options);
+    maybeLog(logger.info, `Ignoring errors while instantiating config: ${message}`, options);
   }
 }
 
-function log(fn: LogFn, message: string, { doNotLogErrors }: ConfigOptions) {
+function maybeLog(fn: LogFn, message: string, { doNotLogErrors }: ConfigOptions) {
   if (doNotLogErrors === true) {
     return;
   }


### PR DESCRIPTION
This PR adds the ability to pass a custom logger to the `newConfig` method.